### PR TITLE
Mostly done with script.

### DIFF
--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -82,10 +82,13 @@ enable_hotplug() {
     ln -f -s "$0" "$HOTPLUG_D_IFACE_SYMLINK" || errex "Failed to create symlink $HOTPLUG_D_IFACE_SYMLINK"
 }
 disable_hotplug() {
-    if [ -L "$HOTPLUG_D_IFACE_SYMLINK" ]; then
+    if [ -e "$HOTPLUG_D_IFACE_SYMLINK" ]; then
         debug "Removing $HOTPLUG_D_IFACE_SYMLINK symlink"
         rm -f "$HOTPLUG_D_IFACE_SYMLINK"
     fi
+}
+is_hotplug_enabled() {
+    [ -e "$HOTPLUG_D_IFACE_SYMLINK" ]
 }
 
 # Returns 0 if script enabled in web UI.
@@ -96,7 +99,6 @@ is_assigned_to_switch() {
 # TODO
 do_toggled_off() {
     info "Toggle switch OFF"
-    disable_hotplug
     enable_2g
     enable_5g
 }
@@ -104,17 +106,18 @@ do_toggled_off() {
 # TODO
 do_toggled_on() {
     info "Toggle switch ON"
-    enable_hotplug
 }
 
 # TODO
 do_wwan_connected() {
+    info "WWAN interface connected"
     debug "ifup: ACTION=$ACTION DEVICE=${DEVICE:-} INTERFACE=$INTERFACE"
     debug "TODO Wait for internet"
 }
 
 # If wwan disconnected
 do_wwan_disconnected() {
+    info "WWAN interface disconnected"
     disable_2g
     disable_5g
 }
@@ -142,23 +145,21 @@ if ! is_assigned_to_switch; then
 fi
 if [ "$1" = off ]; then
     single_instance_priority # In case hotplug runs at the same time switch is toggled off
+    disable_hotplug
     do_toggled_off
 elif [ "$1" = on ]; then
     single_instance
+    enable_hotplug
     do_toggled_on
 elif [ "$ACTION" = ifup ]; then
     single_instance
+    is_hotplug_enabled || errex "Hotplug no longer enabled" # In case hotplug-call queued instances after toggled off
     do_wwan_connected
 elif [ "$ACTION" = ifdown ]; then
     single_instance
+    is_hotplug_enabled || errex "Hotplug no longer enabled"
     do_wwan_disconnected
 else
     debug "ACTION=$ACTION not ifup|ifdown, ignoring"
     exit 0
 fi
-
-# TODOs:
-#   - Single instance, new instance always instantly kills the old instance
-#       - Except when toggling OFF, that takes priority
-#       - gl-switch and hotplug both block and queue, so max of 2 instances expected
-#   - trap set -e with error to logger

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -30,6 +30,65 @@ warning() { _log warn "$*"; }
 info() { _log notice "$*"; }
 debug() { _log debug "$*"; }
 
+# Ensure script runs once at a time.
+single_instance() {
+    : # TODO if priority is running kill self, else kill other instance
+}
+single_instance_priority() {
+    : # TODO kill all other instances and run this one
+}
+
+# Returns 0 if $TOGGLE_BAND_ONLY == true
+toggle_band_only() {
+    [ $TOGGLE_BAND_ONLY = true ]
+}
+
+# Wrapper for `uci set`.
+uci_set() {
+    debug "uci set $1"
+    uci set "$1"
+    debug "uci commit"
+    uci commit
+}
+
+# Enable/disable repeater bands.
+enable_2g() {
+    info "Enabling wifi2g"
+    uci_set "wireless.wifi2g.disabled='0'"
+}
+enable_5g() {
+    info "Enabling wifi5g"
+    uci_set "wireless.wifi5g.disabled='0'"
+}
+disable_2g() {
+    info "Disabling wifi2g"
+    uci_set "wireless.wifi2g.disabled='1'"
+}
+disable_5g() {
+    info "Disabling wifi5g"
+    uci_set "wireless.wifi5g.disabled='1'"
+}
+
+# Wrapper for `ubus call`.
+ubus_call() {
+    output="$(ubus call "$@" |jsonfilter -e @)"
+    debug "ubus call $*: $output"
+    echo "$output"
+}
+
+# Wait for repeater to connect and then get the band it's using.
+get_current_band() {
+    until ubus_call repeater status |jsonfilter -e @.state_s |grep -q '^connected$'; do
+        sleep 1
+    done
+    # TODO wireless.mt798112.band |grep -E '^(2g|5g)$' || true
+}
+
+# TODO
+wait_for_online() {
+    : # TODO until timeout ping; do sleep; done
+}
+
 # Enable/disable being called when the WWAN interface connects or disconnects.
 enable_hotplug() {
     debug "Creating $HOTPLUG_D_IFACE_SYMLINK symlink"
@@ -44,6 +103,7 @@ disable_hotplug() {
 
 # Returns 0 if script enabled in web UI.
 is_assigned_to_switch() {
+    # TODO uci_get wrapper with debug logging
     uci get switch-button.@main[0].func 2>/dev/null |grep -q "^$BASENAME$"
 }
 
@@ -51,6 +111,8 @@ is_assigned_to_switch() {
 do_toggled_off() {
     info "Toggle switch OFF"
     disable_hotplug
+    enable_2g
+    enable_5g
 }
 
 # TODO
@@ -62,14 +124,17 @@ do_toggled_on() {
 # TODO
 do_wwan_connected() {
     debug "ifup: ACTION=$ACTION DEVICE=${DEVICE:-} INTERFACE=$INTERFACE"
-    if [ $TOGGLE_BAND_ONLY != true ]; then
+    if ! toggle_band_only; then
         debug "TODO Wait for internet"
     fi
 }
 
-# TODO
+# If wwan disconnected
 do_wwan_disconnected() {
-    debug "ifdown: ACTION=$ACTION DEVICE=${DEVICE:-} INTERFACE=$INTERFACE"
+    if ! toggle_band_only; then
+        disable_2g
+        disable_5g
+    fi
 }
 
 # Bad arguments.
@@ -94,12 +159,16 @@ if ! is_assigned_to_switch; then
     errex "Not enabled. In the web UI go to System > Toggle Button Settings to enable."
 fi
 if [ "$1" = off ]; then
+    single_instance_priority # In case hotplug runs at the same time switch is toggled off
     do_toggled_off
 elif [ "$1" = on ]; then
+    single_instance
     do_toggled_on
 elif [ "$ACTION" = ifup ]; then
+    single_instance
     do_wwan_connected
 elif [ "$ACTION" = ifdown ]; then
+    single_instance
     do_wwan_disconnected
 else
     debug "ACTION=$ACTION not ifup|ifdown, ignoring"

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -99,23 +99,9 @@ is_assigned_to_switch() {
     uci get switch-button.@main[0].func 2>/dev/null |grep -q "^$BASENAME$"
 }
 
-# TODO
-do_toggled_off() {
-    info "Toggle switch OFF"
-    enable_2g
-    enable_5g
-}
-
-# TODO
-do_toggled_on() {
-    info "Toggle switch ON"
-    if ! is_online; then
-        info "No internet, stopping wifi"
-        disable_2g
-        disable_5g
-        wait_for_online
-    fi
-    band="$(get_current_band)"
+# Toggles on/off the same band used to connect to the internet.
+great_decider() {
+    band="$(get_current_band)"  # Blocks until WiFi connected.
     case "$band" in
     2g)
         enable_5g
@@ -133,14 +119,33 @@ do_toggled_on() {
     esac
 }
 
-# TODO
-do_wwan_connected() {
-    info "WWAN interface connected"
-    debug "ifup: ACTION=$ACTION DEVICE=${DEVICE:-} INTERFACE=$INTERFACE"
-    debug "TODO Wait for internet"
+# Main action when user toggles the switch OFF (also called on boot with the initial switch state of OFF).
+do_toggled_off() {
+    info "Toggle switch OFF"
+    enable_2g
+    enable_5g
 }
 
-# If wwan disconnected
+# Main action when user toggles the switch ON (also called on boot with the initial switch state of ON).
+do_toggled_on() {
+    info "Toggle switch ON"
+    if ! is_online; then
+        info "No internet, stopping wifi"
+        disable_2g
+        disable_5g
+        wait_for_online
+    fi
+    great_decider
+}
+
+# Main action when the repeater connects to a WiFi network.
+do_wwan_connected() {
+    info "WWAN interface connected"
+    wait_for_online
+    great_decider
+}
+
+# Main action when the repeater loses connection.
 do_wwan_disconnected() {
     info "WWAN interface disconnected"
     disable_2g

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -16,7 +16,6 @@ set -o nounset  # Treat unset variables as errors and exit immediately.
 
 BASENAME=wifi-band  # Hardcoding because $0 is /sbin/hotplug-call when called from hotplug.d symlink.
 HOTPLUG_D_IFACE_SYMLINK="/etc/hotplug.d/iface/10-$BASENAME"
-TOGGLE_BAND_ONLY=false  # Set to true if you don't want to bring WiFi down until internet is available.
 
 # Log and print messages to stderr.
 _log() {
@@ -38,55 +37,43 @@ single_instance_priority() {
     : # TODO kill all other instances and run this one
 }
 
-# Returns 0 if $TOGGLE_BAND_ONLY == true
-toggle_band_only() {
-    [ $TOGGLE_BAND_ONLY = true ]
-}
-
-# Wrapper for `uci set`.
-uci_set() {
-    debug "uci set $1"
-    uci set "$1"
-    debug "uci commit"
-    uci commit
-}
-
 # Enable/disable repeater bands.
 enable_2g() {
     info "Enabling wifi2g"
-    uci_set "wireless.wifi2g.disabled='0'"
+    uci set wireless.wifi2g.disabled='0' && uci commit
 }
 enable_5g() {
     info "Enabling wifi5g"
-    uci_set "wireless.wifi5g.disabled='0'"
+    uci set wireless.wifi5g.disabled='0' && uci commit
 }
 disable_2g() {
     info "Disabling wifi2g"
-    uci_set "wireless.wifi2g.disabled='1'"
+    uci set wireless.wifi2g.disabled='1' && uci commit
 }
 disable_5g() {
     info "Disabling wifi5g"
-    uci_set "wireless.wifi5g.disabled='1'"
-}
-
-# Wrapper for `ubus call`.
-ubus_call() {
-    output="$(ubus call "$@" |jsonfilter -e @)"
-    debug "ubus call $*: $output"
-    echo "$output"
+    uci set wireless.wifi5g.disabled='1' && uci commit
 }
 
 # Wait for repeater to connect and then get the band it's using.
 get_current_band() {
-    until ubus_call repeater status |jsonfilter -e @.state_s |grep -q '^connected$'; do
+    until ubus call repeater status |jsonfilter -e @.state_s |grep -q '^connected$'; do
+        debug "Waiting for repeater to connect"
         sleep 1
     done
-    # TODO wireless.mt798112.band |grep -E '^(2g|5g)$' || true
+    device="$(ubus call repeater status |jsonfilter -e @.device)"
+    debug "Conencted using $device"
+    band="$(uci get "wireless.$device.band")"
+    info "Connected on band $band"
+    echo "$band"
 }
 
-# TODO
+# Wait until there is internet available. Blocks indefinitely on portal.
 wait_for_online() {
-    : # TODO until timeout ping; do sleep; done
+    until timeout 1 ping -c1 google.com >/dev/null 2>&1; do
+        debug "Waiting for internet"
+        sleep 1
+    done
 }
 
 # Enable/disable being called when the WWAN interface connects or disconnects.
@@ -103,7 +90,6 @@ disable_hotplug() {
 
 # Returns 0 if script enabled in web UI.
 is_assigned_to_switch() {
-    # TODO uci_get wrapper with debug logging
     uci get switch-button.@main[0].func 2>/dev/null |grep -q "^$BASENAME$"
 }
 
@@ -124,17 +110,13 @@ do_toggled_on() {
 # TODO
 do_wwan_connected() {
     debug "ifup: ACTION=$ACTION DEVICE=${DEVICE:-} INTERFACE=$INTERFACE"
-    if ! toggle_band_only; then
-        debug "TODO Wait for internet"
-    fi
+    debug "TODO Wait for internet"
 }
 
 # If wwan disconnected
 do_wwan_disconnected() {
-    if ! toggle_band_only; then
-        disable_2g
-        disable_5g
-    fi
+    disable_2g
+    disable_5g
 }
 
 # Bad arguments.

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -69,8 +69,11 @@ get_current_band() {
 }
 
 # Wait until there is internet available. Blocks indefinitely on portal.
+is_online() {
+    timeout 1 ping -c1 google.com >/dev/null 2>&1
+}
 wait_for_online() {
-    until timeout 1 ping -c1 google.com >/dev/null 2>&1; do
+    until is_online; do
         debug "Waiting for internet"
         sleep 1
     done
@@ -106,6 +109,28 @@ do_toggled_off() {
 # TODO
 do_toggled_on() {
     info "Toggle switch ON"
+    if ! is_online; then
+        info "No internet, stopping wifi"
+        disable_2g
+        disable_5g
+        wait_for_online
+    fi
+    band="$(get_current_band)"
+    case "$band" in
+    2g)
+        enable_5g
+        disable_2g
+        ;;
+    5g)
+        enable_2g
+        disable_5g
+        ;;
+    *)
+        error "Unexpected band: $band"
+        enable_2g
+        enable_5g
+        ;;
+    esac
 }
 
 # TODO

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -48,15 +48,15 @@ is_assigned_to_switch() {
 }
 
 # TODO
-do_toggled_on() {
-    info "Toggle switch ON"
-    enable_hotplug
-}
-
-# TODO
 do_toggled_off() {
     info "Toggle switch OFF"
     disable_hotplug
+}
+
+# TODO
+do_toggled_on() {
+    info "Toggle switch ON"
+    enable_hotplug
 }
 
 # TODO
@@ -93,10 +93,10 @@ if ! is_assigned_to_switch; then
     disable_hotplug
     errex "Not enabled. In the web UI go to System > Toggle Button Settings to enable."
 fi
-if [ "$1" = on ]; then
-    do_toggled_on
-elif [ "$1" = off ]; then
+if [ "$1" = off ]; then
     do_toggled_off
+elif [ "$1" = on ]; then
+    do_toggled_on
 elif [ "$ACTION" = ifup ]; then
     do_wwan_connected
 elif [ "$ACTION" = ifdown ]; then

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -40,19 +40,21 @@ single_instance_priority() {
 # Enable/disable repeater bands.
 enable_2g() {
     info "Enabling wifi2g"
-    uci set wireless.wifi2g.disabled='0' && uci commit
+    uci set wireless.wifi2g.disabled=0 && uci commit wireless
+    wifi
 }
 enable_5g() {
     info "Enabling wifi5g"
-    uci set wireless.wifi5g.disabled='0' && uci commit
+    uci set wireless.wifi5g.disabled=0 && uci commit wireless
+    wifi
 }
 disable_2g() {
     info "Disabling wifi2g"
-    uci set wireless.wifi2g.disabled='1' && uci commit
+    uci set wireless.wifi2g.disabled=1 && uci commit wireless
 }
 disable_5g() {
     info "Disabling wifi5g"
-    uci set wireless.wifi5g.disabled='1' && uci commit
+    uci set wireless.wifi5g.disabled=1 && uci commit wireless
 }
 
 # Wait for repeater to connect and then get the band it's using.
@@ -62,7 +64,6 @@ get_current_band() {
         sleep 1
     done
     device="$(ubus call repeater status |jsonfilter -e @.device)"
-    debug "Conencted using $device"
     band="$(uci get "wireless.$device.band")"
     info "Connected on band $band"
     echo "$band"
@@ -77,6 +78,7 @@ wait_for_online() {
         debug "Waiting for internet"
         sleep 1
     done
+    info "Internet detected"
 }
 
 # Enable/disable being called when the WWAN interface connects or disconnects.


### PR DESCRIPTION
Seems to work.

No TOGGLE_BAND_ONLY, simplifies script.

HOTPLUG_D_IFACE_SYMLINK hard-coded, safe to rm its value even if it's not a symlink. May get flattened by another utility, handle that edge case.

Not yet implemented: single instance.