### PR TITLE
Fix: wait for VPN

### DIFF
--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -71,15 +71,17 @@ get_current_band() {
 
 # Wait until there is internet available. Blocks indefinitely on portal.
 is_online() {
-    # TODO does not go through the VPN
-    timeout 1 ping -c1 google.com >/dev/null 2>&1
+    if uci get vpnpolicy.global.kill_switch |grep -q '^1$'; then
+        timeout 1 ping -I ovpnclient -c1 google.com >/dev/null 2>&1
+    else
+        timeout 1 ping -c1 google.com >/dev/null 2>&1
+    fi
 }
 wait_for_online() {
     until is_online; do
         debug "Waiting for internet"
         sleep 1
     done
-    info "Internet detected"
 }
 
 # Enable/disable being called when the WWAN interface connects or disconnects.
@@ -138,6 +140,7 @@ do_toggled_on() {
         disable_5g
         wait_for_online
     fi
+    info "Internet detected"
     great_decider
 }
 
@@ -145,6 +148,7 @@ do_toggled_on() {
 do_wwan_connected() {
     info "WWAN interface connected"
     wait_for_online
+    info "Internet detected"
     great_decider
 }
 

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -71,6 +71,7 @@ get_current_band() {
 
 # Wait until there is internet available. Blocks indefinitely on portal.
 is_online() {
+    # TODO does not go through the VPN
     timeout 1 ping -c1 google.com >/dev/null 2>&1
 }
 wait_for_online() {


### PR DESCRIPTION
Pinging out from the router always succeed even when the user enabled the VPN kill switch. This made `is_online` unreliable because it will claim there's internet when the kill switch blocks WiFi clients from accessing the internet until VPN connects.

If the killswitch is enabled ping out through the openvpn client interface to ensure `is_online` returns true when WiFi clients can actually get internet.