### PR TITLE
Single instance, no symlink

### DIFF
--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -34,26 +34,34 @@ debug() { _log debug "$*"; }
 # Kill a running instance and run this one exclusively.
 single_instance() {
     if [ "${1:-}" = clean ]; then
+        debug CLEAN  # TODO remove
         rm "$PIDFILE"
         flock -u 99
+        exec 99>&-
         return
     fi
+    trap "single_instance clean" INT TERM EXIT
+    debug called before exec, "$PIDFILE" has current contents: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
     exec 99>"$LOCKFILE"
+    debug opened "$PIDFILE" has current contents: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
     until flock -n 99; do
+        debug flock exited 1  # TODO remove
         # Priority instances can kill all but non-priority exit if priority is running.
         if [ "${1:-}" != priority ] && grep -q priority "$PIDFILE"; then
             errex "Priority instance running"
         fi
         # Get other instance PID and kill it.
         if target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
-            warning "Killing other instance $target_pid"
-            kill "$target_pid" 2>/dev/null || true
-        else
-            # Race.
-            usleep 100000
+            debug got pid "$target_pid"  # TODO remove
+            debug "killing other instance $target_pid"
+            kill -SIGTERM "$target_pid" 2>/dev/null || debug kill failed # TODO better debug message
         fi
+        sleep 1  # TODO usleep 100000
+        debug end of iteration  # TODO remove
     done
+    debug out of loop  # TODO remove
     [ "${1:-}" = priority ] && echo "$$:priority" >"$PIDFILE" || echo "$$" >"$PIDFILE"
+    debug wrote "$$" to "$PIDFILE" here: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
 }
 
 # Enable/disable repeater bands.
@@ -230,9 +238,6 @@ else
     debug "ACTION=$ACTION not ifup|ifdown, ignoring"
     exit 0
 fi
-
-# Cleanup.
-single_instance clean
 
 # TODOs:
 #   - Look into allowing new instances to run without blocking hotplug and gl-switch.

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -17,6 +17,7 @@ set -o nounset  # Treat unset variables as errors and exit immediately.
 BASENAME="$(basename "${0%.*}")"
 HOTPLUG_SCRIPT="/etc/hotplug.d/iface/10-$BASENAME"
 LOCKFILE="/var/lock/$BASENAME.lock"
+PIDFILE="/var/run/$BASENAME.pid"
 
 # Log and print messages to stderr.
 _log() {
@@ -32,22 +33,27 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
-    exec 9>"$LOCKFILE"
-    until flock -n 9; do
+    if [ "${1:-}" = clean ]; then
+        rm "$PIDFILE"
+        flock -u 99
+        return
+    fi
+    exec 99>"$LOCKFILE"
+    until flock -n 99; do
         # Priority instances can kill all but non-priority exit if priority is running.
-        if [ "${1:-}" != priority ] && grep -q priority "$LOCKFILE"; then
+        if [ "${1:-}" != priority ] && grep -q priority "$PIDFILE"; then
             errex "Priority instance running"
         fi
         # Get other instance PID and kill it.
-        if target_pid="$(grep -Eo "^\d+" "$LOCKFILE")"; then
+        if target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
             warning "Killing other instance $target_pid"
-            kill "$target_pid" 2>/dev/null
+            kill "$target_pid" 2>/dev/null || true
         else
             # Race.
             usleep 100000
         fi
     done
-    [ "${1:-}" = priority ] && echo "$$:priority" >"$LOCKFILE" || echo "$$" >"$LOCKFILE"
+    [ "${1:-}" = priority ] && echo "$$:priority" >"$PIDFILE" || echo "$$" >"$PIDFILE"
 }
 
 # Enable/disable repeater bands.
@@ -224,6 +230,9 @@ else
     debug "ACTION=$ACTION not ifup|ifdown, ignoring"
     exit 0
 fi
+
+# Cleanup.
+single_instance clean
 
 # TODOs:
 #   - Look into allowing new instances to run without blocking hotplug and gl-switch.

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -18,6 +18,7 @@ BASENAME="$(basename "${0%.*}")"
 HOTPLUG_SCRIPT="/etc/hotplug.d/iface/10-$BASENAME"
 LOCKFILE="/var/lock/$BASENAME.lock"
 PIDFILE="/var/run/$BASENAME.pid"
+LOCKTIMEOUT=10
 
 # Log and print messages to stderr.
 _log() {
@@ -33,27 +34,28 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
-    debug called before exec, "$PIDFILE" has current contents: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
-    exec 99>"$LOCKFILE"
-    debug opened "$PIDFILE" has current contents: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
-    until flock -n 99; do
-        debug flock exited 1  # TODO remove
+    starttime="$(date +%s)"
+    killfailed=
+    exec 9>"$LOCKFILE"
+    until flock -n 9; do
         # Priority instances can kill all but non-priority exit if priority is running.
         if [ "${1:-}" != priority ] && grep -q priority "$PIDFILE"; then
             errex "Priority instance running"
         fi
         # Get other instance PID and kill it.
-        if target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
-            debug got pid "$target_pid"  # TODO remove
-            debug "killing other instance $target_pid"
-            kill -9 "-$target_pid" 2>/dev/null || debug kill failed # TODO better debug message
+        if [ -z "$killfailed" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
+            debug "Killing other instance $target_pid"
+            kill -9 "-$target_pid" 2>/dev/null || { warning "Kill failed with $?"; killfailed=1; }
         fi
+        # Timeout.
+        now="$(date +%s)"
+        if [ $(( (now - starttime) )) -gt "$LOCKTIMEOUT" ]; then
+            errex "Timed out waiting for lock"
+        fi
+        # Sleep.
         usleep 250000
-        debug end of iteration  # TODO remove
     done
-    debug out of loop  # TODO remove
     [ "${1:-}" = priority ] && echo "$$:priority" >"$PIDFILE" || echo "$$" >"$PIDFILE"
-    debug wrote "$$" to "$PIDFILE" here: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
 }
 
 # Enable/disable repeater bands.

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -14,8 +14,8 @@
 set -o errexit  # Exit script if a command fails.
 set -o nounset  # Treat unset variables as errors and exit immediately.
 
-BASENAME=wifi-band  # Hardcoding because $0 is /sbin/hotplug-call when called from hotplug.d symlink.
-HOTPLUG_D_IFACE_SYMLINK="/etc/hotplug.d/iface/10-$BASENAME"
+BASENAME="$(basename "${0%.*}")"
+HOTPLUG_SCRIPT="/etc/hotplug.d/iface/10-$BASENAME"
 
 # Log and print messages to stderr.
 _log() {
@@ -86,17 +86,22 @@ wait_for_online() {
 
 # Enable/disable being called when the WWAN interface connects or disconnects.
 enable_hotplug() {
-    debug "Creating $HOTPLUG_D_IFACE_SYMLINK symlink"
-    ln -f -s "$0" "$HOTPLUG_D_IFACE_SYMLINK" || errex "Failed to create symlink $HOTPLUG_D_IFACE_SYMLINK"
+    debug "Creating $HOTPLUG_SCRIPT"
+    { cat > "$HOTPLUG_SCRIPT" <<EOF
+#!/bin/sh
+$0 &
+EOF
+    } || errex "Failed to create $HOTPLUG_SCRIPT"
+    chmod +x "$HOTPLUG_SCRIPT" || errex "Failed to make $HOTPLUG_SCRIPT executable"
 }
 disable_hotplug() {
-    if [ -e "$HOTPLUG_D_IFACE_SYMLINK" ]; then
-        debug "Removing $HOTPLUG_D_IFACE_SYMLINK symlink"
-        rm -f "$HOTPLUG_D_IFACE_SYMLINK"
+    if [ -e "$HOTPLUG_SCRIPT" ]; then
+        debug "Removing $HOTPLUG_SCRIPT"
+        rm -f "$HOTPLUG_SCRIPT"
     fi
 }
 is_hotplug_enabled() {
-    [ -e "$HOTPLUG_D_IFACE_SYMLINK" ]
+    [ -e "$HOTPLUG_SCRIPT" ]
 }
 
 # Returns 0 if script enabled in web UI.

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -32,7 +32,7 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
-    exec 9> "$LOCKFILE"
+    exec 9>"$LOCKFILE"
     until flock -n 9; do
         # Priority instances can kill all but non-priority exit if priority is running.
         if [ "${1:-}" != priority ] && grep -q priority "$LOCKFILE"; then
@@ -41,13 +41,13 @@ single_instance() {
         # Get other instance PID and kill it.
         if target_pid="$(grep -Eo "^\d+" "$LOCKFILE")"; then
             warning "Killing other instance $target_pid"
-            kill "$target_pid"
+            kill "$target_pid" 2>/dev/null
         else
             # Race.
             usleep 100000
         fi
     done
-    [ "${1:-}" = priority ] && echo "$$:priority" > "$LOCKFILE" || echo "$$" > "$LOCKFILE"
+    [ "${1:-}" = priority ] && echo "$$:priority" >"$LOCKFILE" || echo "$$" >"$LOCKFILE"
 }
 
 # Enable/disable repeater bands.

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -33,14 +33,6 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
-    if [ "${1:-}" = clean ]; then
-        debug CLEAN  # TODO remove
-        rm "$PIDFILE"
-        flock -u 99
-        exec 99>&-
-        return
-    fi
-    trap "single_instance clean" INT TERM EXIT
     debug called before exec, "$PIDFILE" has current contents: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
     exec 99>"$LOCKFILE"
     debug opened "$PIDFILE" has current contents: "$(cat "$PIDFILE" 2>/dev/null || true)"  # TODO remove
@@ -54,9 +46,9 @@ single_instance() {
         if target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
             debug got pid "$target_pid"  # TODO remove
             debug "killing other instance $target_pid"
-            kill -SIGTERM "$target_pid" 2>/dev/null || debug kill failed # TODO better debug message
+            kill -9 "-$target_pid" 2>/dev/null || debug kill failed # TODO better debug message
         fi
-        sleep 1  # TODO usleep 100000
+        usleep 250000
         debug end of iteration  # TODO remove
     done
     debug out of loop  # TODO remove

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -16,6 +16,7 @@ set -o nounset  # Treat unset variables as errors and exit immediately.
 
 BASENAME="$(basename "${0%.*}")"
 HOTPLUG_SCRIPT="/etc/hotplug.d/iface/10-$BASENAME"
+LOCKFILE="/var/lock/$BASENAME.lock"
 
 # Log and print messages to stderr.
 _log() {
@@ -29,12 +30,24 @@ warning() { _log warn "$*"; }
 info() { _log notice "$*"; }
 debug() { _log debug "$*"; }
 
-# Ensure script runs once at a time.
+# Kill a running instance and run this one exclusively.
 single_instance() {
-    : # TODO if priority is running kill self, else kill other instance
-}
-single_instance_priority() {
-    : # TODO kill all other instances and run this one
+    exec 9> "$LOCKFILE"
+    until flock -n 9; do
+        # Priority instances can kill all but non-priority exit if priority is running.
+        if [ "${1:-}" != priority ] && grep -q priority "$LOCKFILE"; then
+            errex "Priority instance running"
+        fi
+        # Get other instance PID and kill it.
+        if target_pid="$(grep -Eo "^\d+" "$LOCKFILE")"; then
+            warning "Killing other instance $target_pid"
+            kill "$target_pid"
+        else
+            # Race.
+            usleep 100000
+        fi
+    done
+    [ "${1:-}" = priority ] && echo "$$:priority" > "$LOCKFILE" || echo "$$" > "$LOCKFILE"
 }
 
 # Enable/disable repeater bands.
@@ -178,7 +191,7 @@ fi
 
 # Single instance.
 if [ "$1" = off ]; then
-    single_instance_priority # In case hotplug runs at the same time switch is toggled off
+    single_instance priority # In case hotplug runs at the same time switch is toggled off
 else
     single_instance
 fi

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -165,7 +165,7 @@ if printf '%s\n' "$@" |grep -qE '^(-h|--help|help|[/-][?])$'; then
     errex "more info: https://github.com/Robpol86/glinet-wifi-band-switch"
 elif [ $# -ne 1 ]; then
     errex "requires exactly 1 argument"
-elif [ "$1" != on ] && [ "$1" != off ] && [ "$1" != iface ]; then
+elif [ "$1" != on ] && [ "$1" != on-block ] && [ "$1" != off ] && [ "$1" != iface ]; then
     errex "bad argument, expected on|off|iface but got $1"
 elif [ "$1" = iface ]; then
     [ -n "${ACTION:-}" ] || errex "Missing ACTION variable"
@@ -195,6 +195,9 @@ if [ "$1" = off ]; then
 elif [ "$1" = on ]; then
     info "Toggle switch ON"
     enable_hotplug
+    "$0" on-block &
+    exit 0
+elif [ "$1" = on-block ]; then
     do_toggled_on
 elif [ "$ACTION" = ifup ]; then
     info "WWAN interface connected"

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -89,7 +89,7 @@ enable_hotplug() {
     debug "Creating $HOTPLUG_SCRIPT"
     { cat > "$HOTPLUG_SCRIPT" <<EOF
 #!/bin/sh
-$0 &
+"$0" \$@ &
 EOF
     } || errex "Failed to create $HOTPLUG_SCRIPT"
     chmod +x "$HOTPLUG_SCRIPT" || errex "Failed to make $HOTPLUG_SCRIPT executable"

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -165,7 +165,7 @@ if printf '%s\n' "$@" |grep -qE '^(-h|--help|help|[/-][?])$'; then
     errex "more info: https://github.com/Robpol86/glinet-wifi-band-switch"
 elif [ $# -ne 1 ]; then
     errex "requires exactly 1 argument"
-elif [ "$1" != on ] && [ "$1" != on-block ] && [ "$1" != off ] && [ "$1" != iface ]; then
+elif [ "$1" != on ] && [ "$1" != do_toggled_on ] && [ "$1" != off ] && [ "$1" != iface ]; then
     errex "bad argument, expected on|off|iface but got $1"
 elif [ "$1" = iface ]; then
     [ -n "${ACTION:-}" ] || errex "Missing ACTION variable"
@@ -195,9 +195,9 @@ if [ "$1" = off ]; then
 elif [ "$1" = on ]; then
     info "Toggle switch ON"
     enable_hotplug
-    "$0" on-block &
+    "$0" do_toggled_on &
     exit 0
-elif [ "$1" = on-block ]; then
+elif [ "$1" = do_toggled_on ]; then
     do_toggled_on
 elif [ "$ACTION" = ifup ]; then
     info "WWAN interface connected"

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -34,6 +34,11 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
+    if [ "${1:-}" = clean ]; then
+        flock -u 9
+        exec 9>&-
+        return
+    fi
     starttime="$(date +%s)"
     killfailed=
     exec 9>"$LOCKFILE"
@@ -49,7 +54,7 @@ single_instance() {
         fi
         # Timeout.
         now="$(date +%s)"
-        if [ $(( (now - starttime) )) -gt "$LOCKTIMEOUT" ]; then
+        if [ $(( now - starttime )) -gt "$LOCKTIMEOUT" ]; then
             errex "Timed out waiting for lock"
         fi
         # Sleep.
@@ -216,6 +221,7 @@ if [ "$1" = off ]; then
 elif [ "$1" = on ]; then
     info "Toggle switch ON"
     enable_hotplug
+    single_instance clean # Unlock and close fd before starting subprocess, which inherits every fd from the parent
     "$0" do_toggled_on &
     exit 0
 elif [ "$1" = do_toggled_on ]; then
@@ -232,6 +238,3 @@ else
     debug "ACTION=$ACTION not ifup|ifdown, ignoring"
     exit 0
 fi
-
-# TODOs:
-#   - Look into allowing new instances to run without blocking hotplug and gl-switch.


### PR DESCRIPTION
Implemented single instance with priority support.

Having the script wait in the foreground blocked hotplug. When the router connected and waited for internet, sometimes the interface disconnects. With hotplug blocked these new events aren't handled in time.

Fixing this by running the script in the background via the old symlink, now script. Since hotplug-call no longer directly calls the script we can use `basename` again.

Also avoiding blocking gl-switch by running the expensive do_toggled_on function in a background script.