### PR TITLE
Always release inherited locks

### DIFF
--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -254,3 +254,4 @@ info Done
 # TODOs:
 #   - chmod +x needed for gl-switch?
 #   - ping 4.2.2.1
+#   - disabling wifi no longer actually disabling

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -37,8 +37,8 @@ single_instance() {
     if [ "${1:-}" = unlock ]; then
         grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
             num="${fdinfo##*/}"
-            debug "Closing lock fd $num"
-            eval "exec $num>&-"
+            debug "Release lock on fd $num"
+            flock -u "$num"
         done
         return
     fi

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -34,11 +34,10 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
-    # TODO everything here debug
     if [ "${1:-}" = unlock ]; then
         grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
             num="${fdinfo##*/}"
-            info "Closing lock fd $num"
+            debug "Closing lock fd $num"
             eval "exec $num>&-"
         done
         return
@@ -53,7 +52,7 @@ single_instance() {
         fi
         # Get other instance PID and kill it.
         if [ -z "$killfailed" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
-            info "Killing other instance $target_pid"
+            debug "Killing other instance $target_pid"
             # Kill process group.
             if ! kill -9 "-$target_pid" 2>/dev/null; then
                 killfailed=1
@@ -68,7 +67,7 @@ single_instance() {
         # Sleep.
         usleep 250000
     done
-    info "Obtained lock"
+    debug "Obtained lock"
     [ "${1:-}" = priority ] && echo "$$:priority" >"$PIDFILE" || echo "$$" >"$PIDFILE"
 }
 

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -254,3 +254,4 @@ info Done
 # TODOs:
 #   - Revisit debug vs info
 #   - chmod +x needed for gl-switch?
+#   - ping 4.2.2.1

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -94,7 +94,7 @@ disable_5g() {
 # Wait for repeater to connect and then get the band it's using.
 get_current_band() {
     until ubus call repeater status |jsonfilter -e @.state_s |grep -q '^connected$'; do
-        info "Waiting for repeater to connect"
+        debug "Waiting for repeater to connect"
         sleep 1
     done
     device="$(ubus call repeater status |jsonfilter -e @.device)"
@@ -113,14 +113,14 @@ is_online() {
 }
 wait_for_online() {
     until is_online; do
-        info "Waiting for internet"
+        debug "Waiting for internet"
         sleep 1
     done
 }
 
 # Enable/disable being called when the WWAN interface connects or disconnects.
 enable_hotplug() {
-    info "Creating $HOTPLUG_SCRIPT"
+    debug "Creating $HOTPLUG_SCRIPT"
     { cat > "$HOTPLUG_SCRIPT" <<EOF
 #!/bin/sh
 "$0" \$@ &
@@ -130,7 +130,7 @@ EOF
 }
 disable_hotplug() {
     if [ -e "$HOTPLUG_SCRIPT" ]; then
-        info "Removing $HOTPLUG_SCRIPT"
+        debug "Removing $HOTPLUG_SCRIPT"
         rm -f "$HOTPLUG_SCRIPT"
     fi
 }

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -34,9 +34,12 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
-    if [ "${1:-}" = clean ]; then
-        flock -u 9
-        exec 9>&-
+    if [ "${1:-}" = unlock ]; then
+        grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
+            num="${fdinfo##*/}"
+            debug "Closing fd $num"
+            eval "exec $num>&-"
+        done
         return
     fi
     starttime="$(date +%s)"
@@ -210,6 +213,9 @@ fi
 # Single instance.
 if [ "$1" = off ]; then
     single_instance priority # In case hotplug runs at the same time switch is toggled off
+elif [ "$1" = do_toggled_on ]; then
+    single_instance unlock # Release inherited lock from gl-switch
+    single_instance
 else
     single_instance
 fi
@@ -226,7 +232,6 @@ if [ "$1" = off ]; then
 elif [ "$1" = on ]; then
     info "Toggle switch ON"
     enable_hotplug
-    single_instance clean # Unlock and close fd before starting subprocess, which inherits every fd from the parent
     "$0" do_toggled_on &
     info "Continuing in process $!"
     exit 0

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -34,6 +34,7 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
+    # TODO everything here debug
     if [ "${1:-}" = unlock ]; then
         grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
             num="${fdinfo##*/}"

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -37,7 +37,7 @@ single_instance() {
     if [ "${1:-}" = unlock ]; then
         grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
             num="${fdinfo##*/}"
-            debug "Closing lock fd $num"
+            info "Closing lock fd $num"
             eval "exec $num>&-"
         done
         return
@@ -52,7 +52,7 @@ single_instance() {
         fi
         # Get other instance PID and kill it.
         if [ -z "$killfailed" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
-            debug "Killing other instance $target_pid"
+            info "Killing other instance $target_pid"
             # Kill process group.
             if ! kill -9 "-$target_pid" 2>/dev/null; then
                 killfailed=1
@@ -67,7 +67,7 @@ single_instance() {
         # Sleep.
         usleep 250000
     done
-    debug "Obtained lock"
+    info "Obtained lock"
     [ "${1:-}" = priority ] && echo "$$:priority" >"$PIDFILE" || echo "$$" >"$PIDFILE"
 }
 
@@ -94,7 +94,7 @@ disable_5g() {
 # Wait for repeater to connect and then get the band it's using.
 get_current_band() {
     until ubus call repeater status |jsonfilter -e @.state_s |grep -q '^connected$'; do
-        debug "Waiting for repeater to connect"
+        info "Waiting for repeater to connect"
         sleep 1
     done
     device="$(ubus call repeater status |jsonfilter -e @.device)"
@@ -113,14 +113,14 @@ is_online() {
 }
 wait_for_online() {
     until is_online; do
-        debug "Waiting for internet"
+        info "Waiting for internet"
         sleep 1
     done
 }
 
 # Enable/disable being called when the WWAN interface connects or disconnects.
 enable_hotplug() {
-    debug "Creating $HOTPLUG_SCRIPT"
+    info "Creating $HOTPLUG_SCRIPT"
     { cat > "$HOTPLUG_SCRIPT" <<EOF
 #!/bin/sh
 "$0" \$@ &
@@ -130,7 +130,7 @@ EOF
 }
 disable_hotplug() {
     if [ -e "$HOTPLUG_SCRIPT" ]; then
-        debug "Removing $HOTPLUG_SCRIPT"
+        info "Removing $HOTPLUG_SCRIPT"
         rm -f "$HOTPLUG_SCRIPT"
     fi
 }
@@ -252,6 +252,5 @@ fi
 info Done
 
 # TODOs:
-#   - Revisit debug vs info
 #   - chmod +x needed for gl-switch?
 #   - ping 4.2.2.1

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -34,17 +34,17 @@ debug() { _log debug "$*"; }
 
 # Kill a running instance and run this one exclusively.
 single_instance() {
-    if [ "${1:-}" = unlock ]; then
-        grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
-            num="${fdinfo##*/}"
-            debug "Releasing lock on fd $num"
-            flock -u "$num"
-        done
-        return
-    fi
     starttime="$(date +%s)"
     killfailed=
+    # Release any inherited locks.
+    grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
+        num="${fdinfo##*/}"
+        debug "Releasing lock on fd $num"
+        flock -u "$num"
+    done
+    # Open lock file.
     exec 9>"$LOCKFILE"
+    # Obtain the lock.
     until flock -n 9; do
         # Priority instances can kill all but non-priority exit if priority is running.
         if [ "${1:-}" != priority ] && grep -q priority "$PIDFILE"; then
@@ -213,9 +213,6 @@ fi
 # Single instance.
 if [ "$1" = off ]; then
     single_instance priority # In case hotplug runs at the same time switch is toggled off
-elif [ "$1" = do_toggled_on ]; then
-    single_instance unlock # Release inherited lock from gl-switch
-    single_instance
 else
     single_instance
 fi

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -37,7 +37,7 @@ single_instance() {
     if [ "${1:-}" = unlock ]; then
         grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
             num="${fdinfo##*/}"
-            debug "Closing fd $num"
+            debug "Closing lock fd $num"
             eval "exec $num>&-"
         done
         return
@@ -250,3 +250,7 @@ else
     exit 0
 fi
 info Done
+
+# TODOs:
+#   - Revisit debug vs info
+#   - chmod +x needed for gl-switch?

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -37,7 +37,7 @@ single_instance() {
     if [ "${1:-}" = unlock ]; then
         grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
             num="${fdinfo##*/}"
-            debug "Release lock on fd $num"
+            debug "Releasing lock on fd $num"
             flock -u "$num"
         done
         return


### PR DESCRIPTION
gl-switch uses `flock` as well. This is a problem because:

1. Toggle ON launches this script "in the background" but lock is inherited
2. This script then waits indefinitely "waiting for internet"
3. User toggles switch OFF and expects it to instantly kill the waiting instance
4. Because of the inherited lock gl-switch does not launch a new instance of this script
5. Hangs indefinitely until internet is available.

The fix is to dispose of any inherited lock and manage my own single instance lock. Always dispose of the inherited lock.

Also not able to close inherited file descriptors, but luckily am able to unlock.