### PR TITLE
Kill children holding lock

### DIFF
--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -55,8 +55,9 @@ single_instance() {
             killattempt=1
             debug "Killing other instance $target_pid"
             { kill -9 "-$target_pid" || kill -9 "$target_pid" || debug "FAILED A"; } 2>/dev/null
-            # Kill all subprocesses.
-            grep -lE "^PPid:\s*$target_pid$" /proc/*/status |awk -F/ '{print $3}' |while read -r child_pid; do
+            # Kill all processes holding the lock.
+            lockfie_id="$(grep ^lock: /proc/self/fdinfo/9 |awk '{print $7}')"
+            grep -lE "^lock:.+\s$lockfie_id\s" /proc/*/fdinfo/* 2>/dev/null |awk -F/ '{print $3}' |while read -r child_pid; do
                 debug "Killing child process $child_pid"
                 kill -9 "$child_pid" 2>/dev/null || debug "FAILED B"
             done

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -56,11 +56,11 @@ single_instance() {
             if [ -n "$lockfile_id" ]; then
                 killattempt=1
                 debug "Killing other instance $target_pid"
-                { kill -9 "-$target_pid" || kill -9 "$target_pid" || debug "FAILED A"; } 2>/dev/null
+                { kill -9 "-$target_pid" || kill -9 "$target_pid" || true; } 2>/dev/null
                 # Kill all processes holding the lock.
                 grep -lE "^lock:.+\s$lockfile_id\s" /proc/[0-9]*/fdinfo/* 2>/dev/null |awk -F/ '{print $3}' |while read -r child_pid; do
                     debug "Killing child process $child_pid"
-                    kill -9 "$child_pid" 2>/dev/null || debug "FAILED B"
+                    kill -9 "$child_pid" 2>/dev/null || true
                 done
             fi
         fi
@@ -79,15 +79,21 @@ single_instance() {
 # Enable/disable repeater bands.
 enable_2g() {
     info "Enabling wifi2g"
+    uci set wireless.wifi2g.disabled=0 && uci commit wireless
+    wifi
 }
 enable_5g() {
     info "Enabling wifi5g"
+    uci set wireless.wifi5g.disabled=0 && uci commit wireless
+    wifi
 }
 disable_2g() {
     info "Disabling wifi2g"
+    uci set wireless.wifi2g.disabled=1 && uci commit wireless
 }
 disable_5g() {
     info "Disabling wifi5g"
+    uci set wireless.wifi5g.disabled=1 && uci commit wireless
 }
 
 # Wait for repeater to connect and then get the band it's using.
@@ -113,7 +119,7 @@ is_online() {
 wait_for_online() {
     until is_online; do
         debug "Waiting for internet"
-        sleep 600
+        sleep 1
     done
 }
 

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -54,11 +54,11 @@ single_instance() {
         if [ -z "$killattempt" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
             killattempt=1
             debug "Killing other instance $target_pid"
-            { kill -9 "-$target_pid" || kill -9 "$target_pid" || true; } 2>/dev/null
+            { kill -9 "-$target_pid" || kill -9 "$target_pid" || debug "FAILED A"; } 2>/dev/null
             # Kill all subprocesses.
             grep -lE "^PPid:\s*$target_pid$" /proc/*/status |awk -F/ '{print $3}' |while read -r child_pid; do
                 debug "Killing child process $child_pid"
-                kill -9 "$child_pid" 2>/dev/null || true
+                kill -9 "$child_pid" 2>/dev/null || debug "FAILED B"
             done
         fi
         # Timeout.
@@ -76,21 +76,15 @@ single_instance() {
 # Enable/disable repeater bands.
 enable_2g() {
     info "Enabling wifi2g"
-    uci set wireless.wifi2g.disabled=0 && uci commit wireless
-    wifi
 }
 enable_5g() {
     info "Enabling wifi5g"
-    uci set wireless.wifi5g.disabled=0 && uci commit wireless
-    wifi
 }
 disable_2g() {
     info "Disabling wifi2g"
-    uci set wireless.wifi2g.disabled=1 && uci commit wireless
 }
 disable_5g() {
     info "Disabling wifi5g"
-    uci set wireless.wifi5g.disabled=1 && uci commit wireless
 }
 
 # Wait for repeater to connect and then get the band it's using.
@@ -116,7 +110,7 @@ is_online() {
 wait_for_online() {
     until is_online; do
         debug "Waiting for internet"
-        sleep 1
+        sleep 600
     done
 }
 

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -57,7 +57,7 @@ single_instance() {
             { kill -9 "-$target_pid" || kill -9 "$target_pid" || debug "FAILED A"; } 2>/dev/null
             # Kill all processes holding the lock.
             lockfie_id="$(grep ^lock: /proc/self/fdinfo/9 |awk '{print $7}')"
-            grep -lE "^lock:.+\s$lockfie_id\s" /proc/*/fdinfo/* 2>/dev/null |awk -F/ '{print $3}' |while read -r child_pid; do
+            grep -lE "^lock:.+\s$lockfie_id\s" /proc/[0-9]*/fdinfo/* 2>/dev/null |awk -F/ '{print $3}' |while read -r child_pid; do
                 debug "Killing child process $child_pid"
                 kill -9 "$child_pid" 2>/dev/null || debug "FAILED B"
             done

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -52,15 +52,17 @@ single_instance() {
         fi
         # Get other instance PID and kill it.
         if [ -z "$killattempt" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
-            killattempt=1
-            debug "Killing other instance $target_pid"
-            { kill -9 "-$target_pid" || kill -9 "$target_pid" || debug "FAILED A"; } 2>/dev/null
-            # Kill all processes holding the lock.
-            lockfie_id="$(grep ^lock: /proc/self/fdinfo/9 |awk '{print $7}')"
-            grep -lE "^lock:.+\s$lockfie_id\s" /proc/[0-9]*/fdinfo/* 2>/dev/null |awk -F/ '{print $3}' |while read -r child_pid; do
-                debug "Killing child process $child_pid"
-                kill -9 "$child_pid" 2>/dev/null || debug "FAILED B"
-            done
+            lockfile_id="$(grep ^lock: "/proc/$target_pid/fdinfo/9" 2>/dev/null |awk '{print $7}')"
+            if [ -n "$lockfile_id" ]; then
+                killattempt=1
+                debug "Killing other instance $target_pid"
+                { kill -9 "-$target_pid" || kill -9 "$target_pid" || debug "FAILED A"; } 2>/dev/null
+                # Kill all processes holding the lock.
+                grep -lE "^lock:.+\s$lockfile_id\s" /proc/[0-9]*/fdinfo/* 2>/dev/null |awk -F/ '{print $3}' |while read -r child_pid; do
+                    debug "Killing child process $child_pid"
+                    kill -9 "$child_pid" 2>/dev/null || debug "FAILED B"
+                done
+            fi
         fi
         # Timeout.
         now="$(date +%s)"

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -53,8 +53,21 @@ single_instance() {
         # Get other instance PID and kill it.
         if [ -z "$killfailed" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
             debug "Killing other instance $target_pid"
-            # Kill process group.
-            if ! kill -9 "-$target_pid" 2>/dev/null; then
+            # Kill process group or the process and its children manually.
+            if kill -9 "-$target_pid" 2>/dev/null; then
+                debug "Killed process group $target_pid"
+            elif kill -9 "$target_pid" 2>/dev/null; then
+                debug "Killed process $target_pid"
+                # Kill its childrn.
+                grep -lE "^PPid:\s*$target_pid$" /proc/*/status |awk -F/ '{print $3}' |while read -r child_pid; do
+                    if kill -9 "$child_pid" 2>/dev/null; then
+                        debug "Killed child process $child_pid"
+                    else
+                        killfailed=1
+                        warning "Kill child failed, still waiting for lock..."
+                    fi
+                done
+            else
                 killfailed=1
                 warning "Kill failed, still waiting for lock..."
             fi

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -35,7 +35,7 @@ debug() { _log debug "$*"; }
 # Kill a running instance and run this one exclusively.
 single_instance() {
     starttime="$(date +%s)"
-    killfailed=
+    killattempt=
     # Release any inherited locks.
     grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
         num="${fdinfo##*/}"
@@ -51,26 +51,15 @@ single_instance() {
             errex "Priority instance running"
         fi
         # Get other instance PID and kill it.
-        if [ -z "$killfailed" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
+        if [ -z "$killattempt" ] && target_pid="$(grep -Eo "^\d+" "$PIDFILE")"; then
+            killattempt=1
             debug "Killing other instance $target_pid"
-            # Kill process group or the process and its children manually.
-            if kill -9 "-$target_pid" 2>/dev/null; then
-                debug "Killed process group $target_pid"
-            elif kill -9 "$target_pid" 2>/dev/null; then
-                debug "Killed process $target_pid"
-                # Kill its childrn.
-                grep -lE "^PPid:\s*$target_pid$" /proc/*/status |awk -F/ '{print $3}' |while read -r child_pid; do
-                    if kill -9 "$child_pid" 2>/dev/null; then
-                        debug "Killed child process $child_pid"
-                    else
-                        killfailed=1
-                        warning "Kill child failed, still waiting for lock..."
-                    fi
-                done
-            else
-                killfailed=1
-                warning "Kill failed, still waiting for lock..."
-            fi
+            { kill -9 "-$target_pid" || kill -9 "$target_pid" || true; } 2>/dev/null
+            # Kill all subprocesses.
+            grep -lE "^PPid:\s*$target_pid$" /proc/*/status |awk -F/ '{print $3}' |while read -r child_pid; do
+                debug "Killing child process $child_pid"
+                kill -9 "$child_pid" 2>/dev/null || true
+            done
         fi
         # Timeout.
         now="$(date +%s)"


### PR DESCRIPTION
Solved the problem with sleeps and other subprocesses holding the inherited lock. Now toggling OFF reliably kills the previous script instance and any child processes spawned by it.