### PR TITLE
Enable wifi on portal detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,3 @@ I use this to read logs quickly since there's no `ctrl+r` in ASH.
 ```bash
 lr () ( set -x; logread -e wifi-band -f; )
 ```
-
-## TODOs
-
-- When portal is detected don't disable all interfaces (`grep portal /etc/rc.button/switch`)

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -81,6 +81,7 @@ single_instance() {
 }
 
 update_repeater_status() {
+    debug "Updating repeater status"
     out="$(ubus call repeater status |jsonfilter -e @)"
     repeater_status_device="$(echo "$out" |jsonfilter -e @.device)"
     repeater_status_portal="$(echo "$out" |jsonfilter -e @.portal)"

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -20,6 +20,10 @@ LOCKFILE="/var/lock/$BASENAME.lock"
 PIDFILE="/var/run/$BASENAME.pid"
 LOCKTIMEOUT=10
 
+repeater_status_device=
+repeater_status_portal=
+repeater_status_state_s=
+
 # Log and print messages to stderr.
 _log() {
     level="$1";
@@ -76,6 +80,13 @@ single_instance() {
     [ "${1:-}" = priority ] && echo "$$:priority" >"$PIDFILE" || echo "$$" >"$PIDFILE"
 }
 
+update_repeater_status() {
+    out="$(ubus call repeater status |jsonfilter -e @)"
+    repeater_status_device="$(echo "$out" |jsonfilter -e @.device)"
+    repeater_status_portal="$(echo "$out" |jsonfilter -e @.portal)"
+    repeater_status_state_s="$(echo "$out" |jsonfilter -e @.state_s)"
+}
+
 # Enable/disable repeater bands.
 toggle_bands() {
     if printf '%s\n' "$@" |grep -qE '^(enable_2g)$'; then
@@ -100,17 +111,16 @@ toggle_bands() {
 
 # Wait for repeater to connect and then get the band it's using.
 get_current_band() {
-    until ubus call repeater status |jsonfilter -e @.state_s |grep -q '^connected$'; do
+    until update_repeater_status && echo "$repeater_status_state_s" |grep -q '^connected$'; do
         debug "Waiting for repeater to connect"
         sleep 1
     done
-    device="$(ubus call repeater status |jsonfilter -e @.device)"
-    band="$(uci get "wireless.$device.band")"
+    band="$(uci get "wireless.$repeater_status_device.band")"
     info "Connected on band $band"
     echo "$band"
 }
 
-# Wait until there is internet available. Blocks indefinitely on portal.
+# Wait until there is internet available or if portal detected.
 is_online() {
     if uci get vpnpolicy.global.kill_switch |grep -q '^1$'; then
         timeout 1 ping -I ovpnclient -c1 google.com >/dev/null 2>&1
@@ -118,8 +128,8 @@ is_online() {
         timeout 1 ping -c1 google.com >/dev/null 2>&1
     fi
 }
-wait_for_online() {
-    until is_online; do
+wait_for_portal_or_online() {
+    until update_repeater_status && [ "$repeater_status_portal" = "true" ] || is_online; do
         debug "Waiting for internet"
         sleep 1
     done
@@ -177,7 +187,7 @@ do_toggled_on() {
     if ! is_online; then
         info "No internet, stopping wifi"
         toggle_bands disable_2g disable_5g
-        wait_for_online
+        wait_for_portal_or_online
     fi
     info "Internet detected"
     great_decider
@@ -185,7 +195,7 @@ do_toggled_on() {
 
 # Main action when the repeater connects to a WiFi network.
 do_wwan_connected() {
-    wait_for_online
+    wait_for_portal_or_online
     info "Internet detected"
     great_decider
 }

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -272,6 +272,3 @@ else
     exit 0
 fi
 info Done
-
-# TODOs:
-#   - ping 4.2.2.1

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -77,23 +77,25 @@ single_instance() {
 }
 
 # Enable/disable repeater bands.
-enable_2g() {
-    info "Enabling wifi2g"
-    uci set wireless.wifi2g.disabled=0 && uci commit wireless
+toggle_bands() {
+    if printf '%s\n' "$@" |grep -qE '^(enable_2g)$'; then
+        info "Enabling wifi2g"
+        uci set wireless.wifi2g.disabled=0
+    fi
+    if printf '%s\n' "$@" |grep -qE '^(disable_2g)$'; then
+        info "Disabling wifi2g"
+        uci set wireless.wifi2g.disabled=1
+    fi
+    if printf '%s\n' "$@" |grep -qE '^(enable_5g)$'; then
+        info "Enabling wifi5g"
+        uci set wireless.wifi5g.disabled=0
+    fi
+    if printf '%s\n' "$@" |grep -qE '^(disable_5g)$'; then
+        info "Disabling wifi5g"
+        uci set wireless.wifi5g.disabled=1
+    fi
+    uci commit wireless
     wifi
-}
-enable_5g() {
-    info "Enabling wifi5g"
-    uci set wireless.wifi5g.disabled=0 && uci commit wireless
-    wifi
-}
-disable_2g() {
-    info "Disabling wifi2g"
-    uci set wireless.wifi2g.disabled=1 && uci commit wireless
-}
-disable_5g() {
-    info "Disabling wifi5g"
-    uci set wireless.wifi5g.disabled=1 && uci commit wireless
 }
 
 # Wait for repeater to connect and then get the band it's using.
@@ -153,33 +155,28 @@ great_decider() {
     band="$(get_current_band)"  # Blocks until WiFi connected.
     case "$band" in
     2g)
-        enable_5g
-        disable_2g
+        toggle_bands enable_5g disable_2g
         ;;
     5g)
-        enable_2g
-        disable_5g
+        toggle_bands enable_2g disable_5g
         ;;
     *)
         error "Unexpected band: $band"
-        enable_2g
-        enable_5g
+        toggle_bands enable_2g enable_5g
         ;;
     esac
 }
 
 # Main action when user toggles the switch OFF (also called on boot with the initial switch state of OFF).
 do_toggled_off() {
-    enable_2g
-    enable_5g
+    toggle_bands enable_2g enable_5g
 }
 
 # Main action when user toggles the switch ON (also called on boot with the initial switch state of ON).
 do_toggled_on() {
     if ! is_online; then
         info "No internet, stopping wifi"
-        disable_2g
-        disable_5g
+        toggle_bands disable_2g disable_5g
         wait_for_online
     fi
     info "Internet detected"
@@ -195,8 +192,7 @@ do_wwan_connected() {
 
 # Main action when the repeater loses connection.
 do_wwan_disconnected() {
-    disable_2g
-    disable_5g
+    toggle_bands disable_2g disable_5g
 }
 
 # Bad arguments.
@@ -255,4 +251,3 @@ info Done
 
 # TODOs:
 #   - ping 4.2.2.1
-#   - disabling wifi no longer actually disabling

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -254,6 +254,5 @@ fi
 info Done
 
 # TODOs:
-#   - chmod +x needed for gl-switch?
 #   - ping 4.2.2.1
 #   - disabling wifi no longer actually disabling

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -196,7 +196,6 @@ do_toggled_off() {
 
 # Main action when user toggles the switch ON (also called on boot with the initial switch state of ON).
 do_toggled_on() {
-    update_repeater_status
     if is_online; then
         info "Internet detected"
     elif is_portal; then

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -128,10 +128,21 @@ is_online() {
         timeout 1 ping -c1 google.com >/dev/null 2>&1
     fi
 }
+is_portal() {
+    update_repeater_status && [ "$repeater_status_portal" = "true" ]
+}
 wait_for_portal_or_online() {
-    until update_repeater_status && [ "$repeater_status_portal" = "true" ] || is_online; do
-        debug "Waiting for internet"
-        sleep 1
+    while true; do
+        if is_online; then
+            info "Internet detected"
+            break
+        elif is_portal; then
+            info "Portal detected"
+            break
+        else
+            debug "Waiting for internet"
+            sleep 1
+        fi
     done
 }
 
@@ -184,19 +195,22 @@ do_toggled_off() {
 
 # Main action when user toggles the switch ON (also called on boot with the initial switch state of ON).
 do_toggled_on() {
-    if ! is_online; then
+    update_repeater_status
+    if is_online; then
+        info "Internet detected"
+    elif is_portal; then
+        info "Portal detected"
+    else
         info "No internet, stopping wifi"
         toggle_bands disable_2g disable_5g
         wait_for_portal_or_online
     fi
-    info "Internet detected"
     great_decider
 }
 
 # Main action when the repeater connects to a WiFi network.
 do_wwan_connected() {
     wait_for_portal_or_online
-    info "Internet detected"
     great_decider
 }
 


### PR DESCRIPTION
If the router detects a portal enable the repeater wifi so the user can fill out the form and go online.

This usually will only happen if the portal on a visited wifi network comes back up, like some hotels do every few days or coffee shops every few hours. On new networks with portals the user still has to toggle OFF the switch to disable the script (and enable both bands) so they can access the web UI to connect.