### PR TITLE
Flaky internet and trap EXIT

### DIFF
--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -125,11 +125,15 @@ get_current_band() {
 
 # Wait until there is internet available or if portal detected.
 is_online() {
-    if uci get vpnpolicy.global.kill_switch |grep -q '^1$'; then
-        timeout 1 ping -I ovpnclient -c1 google.com >/dev/null 2>&1
-    else
-        timeout 1 ping -c1 google.com >/dev/null 2>&1
-    fi
+    # Try a few times in case of flaky internet.
+    for _ in $(seq 3 -1 1); do
+        if uci get vpnpolicy.global.kill_switch |grep -q '^1$'; then
+            if timeout 1 ping -I ovpnclient -c1 google.com >/dev/null 2>&1; then return 0; fi
+        else
+            if timeout 1 ping -c1 google.com >/dev/null 2>&1; then return 0; fi
+        fi
+    done
+    return 1
 }
 is_portal() {
     update_repeater_status && [ "$repeater_status_portal" = "true" ]

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -126,11 +126,17 @@ get_current_band() {
 # Wait until there is internet available or if portal detected.
 is_online() {
     # Try a few times in case of flaky internet.
-    for _ in $(seq 3 -1 1); do
+    for i in $(seq 1 3); do
         if uci get vpnpolicy.global.kill_switch |grep -q '^1$'; then
-            if timeout 1 ping -I ovpnclient -c1 google.com >/dev/null 2>&1; then return 0; fi
+            if timeout 1 ping -I ovpnclient -c1 google.com >/dev/null 2>&1; then
+                [ "$i" -eq 1 ] || info "Flaky internet"
+                return 0
+            fi
         else
-            if timeout 1 ping -c1 google.com >/dev/null 2>&1; then return 0; fi
+            if timeout 1 ping -c1 google.com >/dev/null 2>&1; then
+                [ "$i" -eq 1 ] || info "Flaky internet"
+                return 0
+            fi
         fi
     done
     return 1

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -35,6 +35,8 @@ errex() { _log err "$*"; exit 1; }
 warning() { _log warn "$*"; }
 info() { _log notice "$*"; }
 debug() { _log debug "$*"; }
+# shellcheck disable=SC2154 # https://github.com/koalaman/shellcheck/issues/1299
+trap 'ret=$?; [ $ret -eq 0 ] || error "Failed with $ret"' EXIT
 
 # Kill a running instance and run this one exclusively.
 single_instance() {

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -8,7 +8,7 @@
 #       a. scp -O ./wifi-band.sh root@192.168.8.1:/etc/gl-switch.d/wifi-band.sh
 #   2. In the GL.iNet web UI go to System > Toggle Button Settings and select this script
 #   3. Set switch to ON (or if already on set it to OFF then ON)
-# To view logging run:
+# To view logs run:
 #   logread -e wifi-band
 
 set -o errexit  # Exit script if a command fails.


### PR DESCRIPTION
I once say when toggling on whilst connected to wifi, the script say there's no internet and it brought down both bands, then detected internet right after and brought the band back up. Mitigating this with a 3 strike implementation for detecting internet.

Logging when the script has a bug (unset variable or unhandled failed command). Too bad I can't find a way to print `$LINENO` since `ash` traps reset it to 1.