### PR TITLE
DRY: valid_args 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
 # glinet-wifi-band-switch
 
-Prevent GL.iNet GL-MT3000 from repeating on the same band and only bring up WiFi when there is internet available.
+Prevent GL.iNet Beryl AX (GL-MT3000) from repeating on the same band and only bring up WiFi when there is internet available.
 
 To install read the top comment in the main script: [wifi-band.sh](wifi-band.sh)
 
+## Purpose
+
+This script solves two annoyances I had with my Beryl:
+
+1. When I returned to my hotel room and powered it on my laptop would connect to its wifi network but I had no internet.
+   Sometimes internet wouldn't work until I had my laptop disconenct from the Beryl and then re-connect, which instantly gave
+   me internet. I suspect this had something to do with DNS caching on my MacBook.
+2. Every time I connected to hotel WiFI I would need to manually disable the 2.4g or 5g hotspot, depending on which band
+   (frequency, 5 GHz or 2.4 GHz with the Beryl) the hotel WiFi was on. I did this to avoid repeating on the same WiFi band
+   and thus halfing my internet speed. Some of these hotels gave me over 100 Mbit of internet over WiFi!
+
+This script solves both problems. When enabled it detects which band the Beryl is connected to and then disables the same
+frequency hotspot and ensures the other frequency is enabled. It also waits until internet is detected before enablin the
+other frequency.
+
+Of course when I go to a new hotel the Beryl won't have internet. For these situations the side switch on the device can be
+set to OFF which disables this script and enables both hotspot bands. Once I get the device connected to hotel WiFi I can set
+the switch back to ON to resume this script's functionality.
+
 ## Debugging Tips
 
-I use this to read logs quickly since there's no `ctrl+r` in ASH.
+I use this to read logs quickly since there's no `ctrl+r` in ASH. I put it in `~/.profile`.
 
 ```bash
 lr () ( set -x; logread -e wifi-band -f; )

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -43,7 +43,7 @@ single_instance() {
     starttime="$(date +%s)"
     killattempt=
     # Release any inherited locks.
-    grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* |while read -r fdinfo; do
+    grep -lE "FLOCK\s*ADVISORY" /proc/self/fdinfo/* 2>/dev/null |while read -r fdinfo; do
         num="${fdinfo##*/}"
         debug "Releasing lock on fd $num"
         flock -u "$num"
@@ -236,14 +236,17 @@ if printf '%s\n' "$@" |grep -qE '^(-h|--help|help|[/-][?])$'; then
     errex "more info: https://github.com/Robpol86/glinet-wifi-band-switch"
 elif [ $# -ne 1 ]; then
     errex "requires exactly 1 argument"
-elif [ "$1" != on ] && [ "$1" != do_toggled_on ] && [ "$1" != off ] && [ "$1" != iface ]; then
-    errex "bad argument, expected on|off|iface but got $1"
-elif [ "$1" = iface ]; then
-    [ -n "${ACTION:-}" ] || errex "Missing ACTION variable"
-    [ -n "${INTERFACE:-}" ] || errex "Missing INTERFACE variable"
-    if [ "$INTERFACE" != wwan ]; then
-        debug "INTERFACE=$INTERFACE not wwan, ignoring"
-        exit 0
+else
+    valid_args="on|do_toggled_on|off|iface"
+    if ! echo "$1" | grep -qE "^($valid_args)$"; then
+        errex "bad argument, expected $valid_args but got $1"
+    elif [ "$1" = iface ]; then
+        [ -n "${ACTION:-}" ] || errex "Missing ACTION variable"
+        [ -n "${INTERFACE:-}" ] || errex "Missing INTERFACE variable"
+        if [ "$INTERFACE" != wwan ]; then
+            debug "INTERFACE=$INTERFACE not wwan, ignoring"
+            exit 0
+        fi
     fi
 fi
 


### PR DESCRIPTION
Code drifted away from error message. Refactored this part of the script
to keep consistent in the future.

Silencing grep's race condition when reading files in `/proc`.