### PR TITLE
PING_HOST and SLEEP_FOR

### DIFF
--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -27,6 +27,7 @@ HOTPLUG_SCRIPT="/etc/hotplug.d/iface/10-$BASENAME"
 LOCKFILE="/var/lock/$BASENAME.lock"
 PIDFILE="/var/run/$BASENAME.pid"
 LOCKTIMEOUT=10
+PING_HOST=1.1.1.1
 
 repeater_status_device=
 repeater_status_portal=
@@ -140,12 +141,12 @@ is_online() {
     # Try a few times in case of flaky internet.
     for i in $(seq 1 3); do
         if uci get vpnpolicy.global.kill_switch |grep -q '^1$'; then
-            if timeout 1 ping -I ovpnclient -c1 google.com >/dev/null 2>&1; then
+            if timeout 1 ping -I ovpnclient -c1 "$PING_HOST" >/dev/null 2>&1; then
                 [ "$i" -eq 1 ] || info "Flaky internet"
                 return 0
             fi
         else
-            if timeout 1 ping -c1 google.com >/dev/null 2>&1; then
+            if timeout 1 ping -c1 "$PING_HOST" >/dev/null 2>&1; then
                 [ "$i" -eq 1 ] || info "Flaky internet"
                 return 0
             fi

--- a/wifi-band.sh
+++ b/wifi-band.sh
@@ -28,6 +28,7 @@ LOCKFILE="/var/lock/$BASENAME.lock"
 PIDFILE="/var/run/$BASENAME.pid"
 LOCKTIMEOUT=10
 PING_HOST=1.1.1.1
+SLEEP_FOR=5
 
 repeater_status_device=
 repeater_status_portal=
@@ -129,7 +130,7 @@ toggle_bands() {
 get_current_band() {
     until update_repeater_status && echo "$repeater_status_state_s" |grep -q '^connected$'; do
         debug "Waiting for repeater to connect"
-        sleep 1
+        sleep "$SLEEP_FOR"
     done
     band="$(uci get "wireless.$repeater_status_device.band")"
     info "Connected on band $band"
@@ -167,7 +168,7 @@ wait_for_portal_or_online() {
             break
         else
             debug "Waiting for internet"
-            sleep 1
+            sleep "$SLEEP_FOR"
         fi
     done
 }


### PR DESCRIPTION
Switch to PING_HOST 

Pinging IP instead of a hostname to work around DNS issues at some
coffee shops.

SLEEP_FOR 

Extending period from 1 second to 5 to reduce drowning out log messages
from other processes on the router.